### PR TITLE
Incorrect method call in spherical_site_collection

### DIFF
--- a/site_analysis/spherical_site_collection.py
+++ b/site_analysis/spherical_site_collection.py
@@ -6,7 +6,7 @@ class SphericalSiteCollection(SiteCollection):
 
     def analyse_structure(self, atoms, structure):
         for a in atoms:
-            a.get_coords(structure)
+            a.assign_coords(structure)
         self.assign_site_occupations(atoms, structure)
 
     def assign_site_occupations(self, atoms, structure):


### PR DESCRIPTION
I think I've spotted a bug in the spherical_site_collection module where a `get_coords` method call is made on an `Atom` object - this method does not exist. A brief glance at the other site_collection modules implies that this is a simple typo and should be replaced with the `assign_coords` method which is indeed implemented in the `Atom` class.