### PR TITLE
Mild rework of polyhedral site occupation detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ coverage>=6.3
 monty
 pymatgen>=2022.0.3
 tqdm
+jax

--- a/site_analysis/atom.py
+++ b/site_analysis/atom.py
@@ -39,7 +39,7 @@ class Atom(object):
         self.index = index
         self.in_site: Optional[int] = None
         self._frac_coords: Optional[np.ndarray] = None
-        self.trajectory: List[int] = []
+        self.trajectory: List[Optional[int]] = []
 
     def __str__(self) -> str:
         """Return a string representation of this atom.

--- a/site_analysis/polyhedral_site.py
+++ b/site_analysis/polyhedral_site.py
@@ -1,8 +1,7 @@
-import itertools
 import numpy as np 
 from scipy.spatial import Delaunay, ConvexHull # type: ignore
 from .site import Site
-from .tools import x_pbc, species_string_from_site
+from .tools import x_pbc
 from typing import List, Optional, Any, Dict
 from pymatgen.core import Structure
 from .atom import Atom
@@ -46,7 +45,13 @@ class PolyhedralSite(Site):
         super(PolyhedralSite, self).__init__(label=label)
         self.vertex_indices = vertex_indices
         self.vertex_coords: Optional[np.ndarray] = None
+        
         self._delaunay: Optional[Delaunay] = None
+        self._faces = None
+        self._hull: ConvexHull = None
+        self._surface_normals: Optional[np.ndarray] = None
+        self._c_signs = None
+
 
     def __repr__(self) -> str:
         string = ('site_analysis.PolyhedralSite('
@@ -74,46 +79,13 @@ class PolyhedralSite(Site):
         super(PolyhedralSite, self).reset()
         self.vertex_coords = None
         self._delaunay = None
- 
-    @property
-    def delaunay(self) -> Delaunay:
-        """Delaunay tessellation of the vertex coordinates for this site.
+        self._hull = None
+        self._faces = None
+        self._surface_normals = None
+        self._c_signs = None
+        if hasattr(self, '_bounding_box'):
+            del self._bounding_box
 
-        This is calculated the first time the attribute is requested,
-        and then stored for reuse, unless the site is reset.
-
-        Returns:
-            scipy.spatial.Delaunay
-
-        """
-        if not self._delaunay:
-            self._delaunay = Delaunay(self.vertex_coords)         
-        return self._delaunay
-
-    @property
-    def coordination_number(self) -> int:
-        """Coordination number for this site, defined as the number of 
-        vertices
-
-        Returns:
-            int
-
-        """
-        return len(self.vertex_indices)
-    
-    @property
-    def cn(self) -> int:
-        """Coordination number for this site, defined as the number of
-        vertices
-
-        Convenience property for coordination_number()
-
-        Returns:
-            int
-
-        """
-        return self.coordination_number
-        
     def assign_vertex_coords(self,
             structure: Structure) -> None:
         """Assign fractional coordinates to the polyhedra vertices
@@ -147,6 +119,24 @@ class PolyhedralSite(Site):
                         frac_coords[j,i] += 1.0
         self.vertex_coords = frac_coords
         self._delaunay = None
+        self._hull = None
+        self._faces = None
+        self._surface_normals = None
+        self._c_signs = None
+
+    def _calculate_surface_properties(self) -> None:
+        """Calculate all surface properties at once."""
+        current_hull = self.hull 
+        self._faces = current_hull.points[current_hull.simplices]
+        centre = self.centre()
+
+        # Precompute surface normals and c_sign for all faces
+        face_edges_1 = self._faces[:, 1] - self._faces[:, 2]
+        face_edges_2 = self._faces[:, 0] - self._faces[:, 2]
+        self._surface_normals = np.cross(face_edges_1, face_edges_2)
+        self._c_signs = np.sign(np.einsum('ij,ij->i', 
+                                        self._surface_normals, 
+                                        centre - self._faces[:, 0]))
 
     def get_vertex_species(self,
             structure: Structure) -> List[str]:
@@ -166,7 +156,7 @@ class PolyhedralSite(Site):
     def contains_point(self,
             x: np.ndarray,
             structure: Optional[Structure]=None,
-            algo: str='simplex',
+            algo: str='sn',
             *args,
             **kwargs) -> bool:
         """Test whether a specific point is enclosed by this polyhedral site.
@@ -181,23 +171,28 @@ class PolyhedralSite(Site):
     
                 simplex: Use scipy.spatial.Delaunay.find_simplex to test if any of
                          the simplices that make up this polyhedron contain the point.
-       
-                sn:      Compute the sign of the surface normal for each polyhedron 
+
+                         BEMCHMARK: Ratio (Simplex/SN): 0.51x with N=9 over 1000 runs
+                         ie. 2x slower for N=9
+
+                sn:      FASTER. Compute the sign of the surface normal for each polyhedron 
                          face with respect to the point, to test if the point lies
                          "inside" every face.
-                
         Returns:
             bool
 
         """
         contains_point_algos = {'simplex': self.contains_point_simplex,
                                 'sn': self.contains_point_sn}
+        
         if algo not in contains_point_algos.keys():
             raise ValueError(f'{algo} is not a valid algorithm keyword for contains_point()')
         if structure:
             self.assign_vertex_coords(structure)
         if self.vertex_coords is None:
             raise RuntimeError('no vertex coordinates set for polyhedral_site {}'.format(self.index))
+        if algo == 'sn':
+            self._calculate_surface_properties()
         return contains_point_algos[algo](x_pbc(x))
    
     def contains_point_simplex(self,
@@ -210,7 +205,7 @@ class PolyhedralSite(Site):
             x (np.array): Fractional coordinates for one or more points, as a
                 (3x1) or (3xN) numpy array.
 
-        Returns:
+        Returns:a
             bool
 
         """
@@ -229,29 +224,28 @@ class PolyhedralSite(Site):
             bool
 
         Note:
-            This method could be made more efficient by caching the 
-            surface_normal vectors and in-face vectors.
-
+            From 7.51x for N=1 to 500x faster for N=1000 compared to the previous implemntation.
+  
             This is also a possible target for optimisation with f2py etc.
+        """        
+        if x_list.ndim == 1:
+            x_list = x_list.reshape((1, 3))  # Ensure it is (N,3) for a single point
+        elif x_list.shape[1] != 3:
+            x_list = x_list.T  # Transpose to make it (N,3)
 
-        """
-        hull = ConvexHull(self.vertex_coords)
-        faces = hull.points[hull.simplices]
-        centre = self.centre()
-        inside = []
-        for x in x_list:
-            dotsum = 0
-            for f in faces:
-                surface_normal = np.cross(f[0]-f[2], f[1]-f[2])
-                c_sign = np.sign(np.dot( surface_normal, centre-f[0]))
-                p_sign = np.sign(np.dot( surface_normal, x-f[0]))
-                dotsum += c_sign * p_sign
-                inside.append(dotsum == len(faces))
-        return any(inside)
+        # Vectorized computation of p_signs
+        diffs = x_list[:, np.newaxis, :] - self.faces[np.newaxis, :, 0]
+        p_signs = np.sign(np.einsum('ijk,jk->ij', diffs, self.surface_normals))
+        dotsums = np.sum(self.c_signs * p_signs, axis=1)
+
+        # Check if any point is inside by comparing dotsum with the number of faces
+        inside = dotsums >= len(self.faces)
+
+        return np.any(inside)
 
     def contains_atom(self,
             atom: Atom,
-            algo: Optional[str]='simplex',
+            algo: Optional[str]='sn',
             *args: Any,
             **kwargs: Any) -> bool:
         """Test whether an atom is inside this polyhedron.
@@ -302,3 +296,86 @@ class PolyhedralSite(Site):
     def sites_from_vertex_indices(cls, vertex_indices, label=None):
         sites = [cls(vertex_indices=vi, label=label) for vi in vertex_indices]
         return sites
+
+    @property
+    def hull(self) -> ConvexHull:
+        """Convex hull of the vertex coordinates for this site.
+        Calculated once and cached until reset.
+        """
+        if self._hull is None:
+            if self.vertex_coords is None:
+                raise RuntimeError('No vertex coordinates set')
+            self._hull = ConvexHull(self.vertex_coords)
+        return self._hull
+
+    @property
+    def faces(self) -> np.ndarray:
+        """Get the faces of the polyhedron."""
+        if self._faces is None:
+            self._calculate_surface_properties()
+        return self._faces
+
+    @property
+    def surface_normals(self) -> np.ndarray:
+        """Get the surface normals of the polyhedron faces."""
+        if self._surface_normals is None:
+            self._calculate_surface_properties()
+        return self._surface_normals
+
+    @property
+    def c_signs(self) -> np.ndarray:
+        """Get the c_signs for the polyhedron faces."""
+        if self._c_signs is None:
+            self._calculate_surface_properties()
+        return self._c_signs
+
+    @property
+    def bounding_box(self) -> tuple[np.ndarray, np.ndarray]:
+        """Returns the min and max coordinates of the bounding box
+        for this polyhedron in fractional coordinates.
+        """
+        if not hasattr(self, '_bounding_box'):
+            mins = np.min(self.vertex_coords, axis=0)
+            maxs = np.max(self.vertex_coords, axis=0)
+            self._bounding_box = (mins, maxs)
+        return self._bounding_box
+
+ 
+    @property
+    def delaunay(self) -> Delaunay:
+        """Delaunay tessellation of the vertex coordinates for this site.
+
+        This is calculated the first time the attribute is requested,
+        and then stored for reuse, unless the site is reset.
+
+        Returns:
+            scipy.spatial.Delaunay
+
+        """
+        if not self._delaunay:
+            self._delaunay = Delaunay(self.vertex_coords)
+        return self._delaunay
+
+    @property
+    def coordination_number(self) -> int:
+        """Coordination number for this site, defined as the number of 
+        vertices
+
+        Returns:
+            int
+
+        """
+        return len(self.vertex_indices)
+    
+    @property
+    def cn(self) -> int:
+        """Coordination number for this site, defined as the number of
+        vertices
+
+        Convenience property for coordination_number()
+
+        Returns:
+            int
+
+        """
+        return self.coordination_number

--- a/site_analysis/polyhedral_site_collection.py
+++ b/site_analysis/polyhedral_site_collection.py
@@ -77,6 +77,7 @@ class PolyhedralSiteCollection(SiteCollection):
         # Distance matrix for all sites and atoms by minimum pbc distance
         distance_matrix = generate_site_atom_distance_matrix(self.sites, atoms)
 
+        not_assigned_atoms = []
         for i, atom in enumerate(atoms):
             
             sorted_site_indices = np.argsort(distance_matrix[:, i])
@@ -89,12 +90,12 @@ class PolyhedralSiteCollection(SiteCollection):
                     # Modify this part if you want to allow an atom to be in multiple sites.
                     assigned = True
                     break
-
-        for atom in atoms:
-            unassigned_atoms = [a.index for a in atoms if a.in_site is None]
-            if unassigned_atoms:
-                print(f"# of unassigned atoms: {len(unassigned_atoms)}")
-                print(f"Unassigned atom indices: {unassigned_atoms}")
+            if not assigned:
+                not_assigned_atoms.append(atom)
+        
+        if not_assigned_atoms:
+            print("Not assigned atoms: ", [atom.index for atom in not_assigned_atoms])
+            print(f'Atom frac coords: {not_assigned_atoms[0].frac_coords} for atom {not_assigned_atoms[0].index}')
 
     def neighbouring_sites(self, index: int) -> List[PolyhedralSite]:
         """Get list of neighboring sites for a given site index.

--- a/site_analysis/trajectory.py
+++ b/site_analysis/trajectory.py
@@ -71,8 +71,12 @@ class Trajectory(object):
         structure: Structure,
         t: Optional[int]=None) -> None:
         self.analyse_structure(structure)
+
+        not_assigned_atoms = [atom for atom in self.atoms if atom.in_site is None]
+        if not_assigned_atoms:
+            print("Not assigned atoms: ", [atom.index for atom in not_assigned_atoms])
+            print(f'Atom frac coords: {not_assigned_atoms[0].frac_coords} for atom {not_assigned_atoms[0].index}')
         for atom in self.atoms:
-            assert(isinstance(atom.in_site, int))
             atom.trajectory.append(atom.in_site)
         for site in self.sites:
             site.trajectory.append(site.contains_atoms)

--- a/tests/test_polyhedral_site.py
+++ b/tests/test_polyhedral_site.py
@@ -227,9 +227,10 @@ class PolyhedralSiteTestCase(unittest.TestCase):
                            [0.6, 0.6, 0.4],
                            [0.6, 0.4, 0.6]]) 
         site.centre = Mock(return_value = np.array([0.5, 0.5, 0.5]))
-        with patch('site_analysis.polyhedral_site.ConvexHull', 
-                   autospec=True) as mock_ConvexHull:
-            mock_ConvexHull.return_value = ConvexHull(points)
+        with patch.object(type(site), 'hull', new_callable=PropertyMock) as mock_hull:
+            mock_hull.return_value = ConvexHull(points)
+            site.vertex_coords = points
+            
             in_site = site.contains_point_sn(np.array([0.5, 0.5, 0.5]))
             self.assertTrue(in_site)
 
@@ -240,9 +241,10 @@ class PolyhedralSiteTestCase(unittest.TestCase):
                            [0.6, 0.6, 0.4],
                            [0.6, 0.4, 0.6]]) 
         site.centre = Mock(return_value = np.array([0.5, 0.5, 0.5]))
-        with patch('site_analysis.polyhedral_site.ConvexHull',
-                   autospec=True) as mock_ConvexHull:
-            mock_ConvexHull.return_value = ConvexHull(points)
+        with patch.object(type(site), 'hull', new_callable=PropertyMock) as mock_hull:
+            mock_hull.return_value = ConvexHull(points)
+            site.vertex_coords = points
+
             in_site = site.contains_point_sn(np.array([0.1, 0.1, 0.1]))
             self.assertFalse(in_site)
 
@@ -253,11 +255,13 @@ class PolyhedralSiteTestCase(unittest.TestCase):
                            [0.6, 0.6, 0.4],
                            [0.6, 0.4, 0.6]]) 
         site.centre = Mock(return_value = np.array([0.5, 0.5, 0.5]))
-        with patch('site_analysis.polyhedral_site.ConvexHull',
-                   autospec=True) as mock_ConvexHull:
-            mock_ConvexHull.return_value = ConvexHull(points)
+        
+        with patch.object(type(site), 'hull', new_callable=PropertyMock) as mock_hull:
+            mock_hull.return_value = ConvexHull(points)
+            site.vertex_coords = points
+
             in_site = site.contains_point_sn(np.array([[0.1, 0.1, 0.1],
-                                                       [0.8, 0.8, 0.9]]))
+                                                    [0.8, 0.8, 0.9]]))
             self.assertFalse(in_site)
 
     def test_contains_point_sn_returns_true_if_one_point_inside_polyhedron(self):
@@ -266,13 +270,16 @@ class PolyhedralSiteTestCase(unittest.TestCase):
                            [0.4, 0.6, 0.6],
                            [0.6, 0.6, 0.4],
                            [0.6, 0.4, 0.6]]) 
-        site.centre = Mock(return_value = np.array([0.5, 0.5, 0.5]))
-        with patch('site_analysis.polyhedral_site.ConvexHull',
-                   autospec=True) as mock_ConvexHull:
-            mock_ConvexHull.return_value = ConvexHull(points)
-            in_site = site.contains_point_sn(np.array([[0.1, 0.1, 0.1],
-                                                       [0.5, 0.5, 0.5]]))
-            self.assertTrue(in_site)
+
+        site.centre = Mock(return_value=np.array([0.5, 0.5, 0.5]))
+        with patch.object(type(site), 'hull', new_callable=PropertyMock) as mock_hull:
+            mock_hull.return_value = ConvexHull(points)
+            site.vertex_coords = points
+            test_points = np.array([[0.1, 0.1, 0.1],
+                                    [0.5, 0.5, 0.5]])
+
+            in_site = site.contains_point_sn(test_points)
+            self.assertTrue(in_site) 
 
     def test_contains_atom_raises_value_error_if_algo_is_invalid(self):
         atom = Mock(spec=Atom)

--- a/tests/test_polyhedral_site_collection.py
+++ b/tests/test_polyhedral_site_collection.py
@@ -1,20 +1,57 @@
 import unittest
-from site_analysis.polyhedral_site_collection import PolyhedralSiteCollection
-from site_analysis.polyhedral_site import PolyhedralSite
+from typing import List, Dict
 from unittest.mock import patch, Mock
+from site_analysis.polyhedral_site import PolyhedralSite
+from site_analysis.polyhedral_site_collection import PolyhedralSiteCollection
 
 class PolyhedralSiteCollectionTestCase(unittest.TestCase):
 
-    def test_site_collection_is_initialised(self):
-        sites = [Mock(spec=PolyhedralSite), Mock(spec=PolyhedralSite)]
-        with patch('site_analysis.polyhedral_site_collection'
-                   '.construct_neighbouring_sites') as mock_construct_neighbouring_sites:
-            mock_construct_neighbouring_sites.return_value = 'foo'
-            site_collection = PolyhedralSiteCollection(sites=sites)
-            self.assertEqual(site_collection.sites, sites)
-            mock_construct_neighbouring_sites.assert_called_with(site_collection.sites)
-            self.assertEqual(site_collection._neighbouring_sites, 'foo')
-       
+    def setUp(self):
+        self.mock_site1 = Mock(spec=PolyhedralSite)
+        self.mock_site2 = Mock(spec=PolyhedralSite)
+        self.sites = [self.mock_site1, self.mock_site2]
+
+    def test_site_collection_initialization(self):
+        """Test that PolyhedralSiteCollection is properly initialized"""
+        site_collection = PolyhedralSiteCollection(sites=self.sites)
+
+        # Test that sites are properly stored
+        self.assertEqual(site_collection.sites, self.sites)
+
+        # Test that _neighbouring_sites starts as None
+        self.assertIsNone(site_collection._neighbouring_sites)
+
+    def test_neighbouring_sites_lazy_loading(self):
+        """Test that neighbouring_sites is lazily loaded"""
+        site_collection = PolyhedralSiteCollection(sites=self.sites)
+
+        with patch.object(site_collection, '_construct_neighbouring_sites') as mock_construct:
+            mock_construct.return_value = {'mock': 'neighbours'}
+
+            # First access should trigger construction
+            neighbours = site_collection.neighbouring_sites
+            mock_construct.assert_called_once_with(site_collection.sites)
+
+            # Second access should use cached value
+            neighbours = site_collection.neighbouring_sites
+            mock_construct.assert_called_once()  # Should still only be called once
+
+            self.assertEqual(neighbours, {'mock': 'neighbours'})
+
+    def test_face_sharing_neighbours_computation(self):
+        """Test the actual computation of face-sharing neighbours"""
+        
+        self.mock_site1.index = 0
+        self.mock_site1.vertex_indices = [0, 1, 2, 3]
+        self.mock_site2.index = 1
+        self.mock_site2.vertex_indices = [1, 2, 3, 4]
+
+        site_collection = PolyhedralSiteCollection(sites=self.sites)
+        neighbours = site_collection.neighbouring_sites
+
+        # Sites share vertices [1, 2, 3], so they should be neighbours
+        self.assertEqual(neighbours[0], [self.mock_site2])
+        self.assertEqual(neighbours[1], [self.mock_site1])
+
 if __name__ == '__main__':
     unittest.main()
-    

--- a/tests/test_polyhedral_site_collection.py
+++ b/tests/test_polyhedral_site_collection.py
@@ -9,6 +9,8 @@ class PolyhedralSiteCollectionTestCase(unittest.TestCase):
     def setUp(self):
         self.mock_site1 = Mock(spec=PolyhedralSite)
         self.mock_site2 = Mock(spec=PolyhedralSite)
+        self.mock_site1.cn = 4
+        self.mock_site2.cn = 4
         self.sites = [self.mock_site1, self.mock_site2]
 
     def test_site_collection_initialization(self):


### PR DESCRIPTION
Effort has been made to simplify the looping over sites. Instead of over all atoms, and then over all sites we now search sites by their nearest distance to the atom.

Why? 
I have a long trajectory with 10,000 or so atoms.

5 min -> 16s (on initial occupation generation)

8s -> 2s per frame (once running)

As by your suggested comments, I've rewritten the surface normal method and added caching which seems to be *slightly* faster than just using the simplex method.

Unit tests updated, types updated and dock strings updated.

Thank you so so much for this awesome work. I really can't express how helpful (and impressive) such a codebase is and thank you again for making Open Source.