### PR TITLE
Development updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
       
       - name: Static type checking
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "site_analysis"
-version = "0.3.1"
-description = "Analysis tools for tracking ion migration pathways through crystallographic sites"
+version = "0.4.0"
+description = "Analysis tools for tracking ion migration through crystallographic sites"
 readme = "README.md"
 authors = [
     {name = "Benjamin J. Morgan", email = "example@email.com"}

--- a/site_analysis/builders.py
+++ b/site_analysis/builders.py
@@ -115,7 +115,15 @@ class TrajectoryBuilder:
 		self.reset()
 	
 	def reset(self) -> 'TrajectoryBuilder':
-		"""Reset the builder state to default values."""
+		"""Reset the builder state to default values.
+		
+		 This method clears all configuration and returns the builder to its
+		 initial state. It is called automatically during initialization and
+		 after build(), but can also be called explicitly if needed.
+		 
+		 Returns:
+			 self: For method chaining
+		 """
 		self._structure: Optional[Structure] = None
 		self._reference_structure: Optional[Structure]= None
 		self._mobile_species: Optional[str|list[str]] = None

--- a/site_analysis/builders.py
+++ b/site_analysis/builders.py
@@ -124,21 +124,21 @@ class TrajectoryBuilder:
 		Returns:
 			self: For method chaining
 		"""
-		self._structure = None
-		self._reference_structure = None
-		self._mobile_species = None
-		self._atoms = None
+		self._structure: Optional[Structure] = None
+		self._reference_structure: Optional[Structure]= None
+		self._mobile_species: Optional[str|list[str]] = None
+		self._atoms: Optional[list[Atom]] = None
 		
 		# Alignment options
 		self._align = True
-		self._align_species = None
+		self._align_species: Optional[list[str]] = None
 		self._align_metric = 'rmsd'
 		
 		# Mapping options
-		self._mapping_species = None
+		self._mapping_species: Optional[list[str]] = None
 		
 		# Functions to be called during build() to create sites
-		self._site_generators = []
+		self._site_generators: list[Callable] = []
 		
 		return self
 		

--- a/site_analysis/builders.py
+++ b/site_analysis/builders.py
@@ -224,15 +224,37 @@ class TrajectoryBuilder:
 		return self
 		
 	def with_spherical_sites(self, 
-						centres: list[list[float]], 
-						radii: list[float], 
-						labels: Optional[list[str]] = None) -> TrajectoryBuilder:
+					centres: list[list[float]], 
+					radii: Union[float, list[float]], 
+					labels: Optional[Union[str, list[str]]] = None) -> TrajectoryBuilder:
 		"""Define spherical sites.
 		
 		Note: Sites will be generated when build() is called.
+		
+		Args:
+			centres: list of fractional coordinate centres for spherical sites
+			radii: either a single radius (float) to use for all sites, or a list 
+				of radii (one per centre)
+			labels: either a single label (str) to use for all sites, a list of 
+				labels (one per centre), or None
+			
+		Returns:
+			self: For method chaining
 		"""
+		# Convert single radius to list if needed
+		if isinstance(radii, (float, int)):
+			radii = [radii] * len(centres)
+			
+		# Convert single label to list if needed
+		if isinstance(labels, str):
+			labels = [labels] * len(centres)
+			
+		# Validate lengths
 		if len(centres) != len(radii):
 			raise ValueError("Number of centres must match number of radii")
+			
+		if labels is not None and len(centres) != len(labels):
+			raise ValueError("Number of centres must match number of labels")
 			
 		# Define the site generation function but don't execute it yet
 		def create_spherical_sites() -> Sequence[SphericalSite]:
@@ -467,8 +489,8 @@ def create_trajectory_with_spherical_sites(
 	structure, 
 	mobile_species: Union[str, list[str]], 
 	centres: list[list[float]], 
-	radii: list[float], 
-	labels: Optional[list[str]] = None
+	radii: Union[float, list[float]], 
+	labels: Optional[Union[str, list[str]]] = None
 ) -> Trajectory:
 	"""Create a Trajectory with spherical sites.
 	
@@ -476,8 +498,10 @@ def create_trajectory_with_spherical_sites(
 		structure: Structure containing the atoms to analyse
 		mobile_species: Species string or list of species strings for mobile atoms
 		centres: list of fractional coordinate centres for spherical sites
-		radii: list of radii for spherical sites (in Angstroms)
-		labels: Optional list of labels for sites
+		radii: either a single radius (float) to use for all sites, or a list 
+			of radii (one per centre) in Angstroms
+		labels: Optional single label (str) to use for all sites, or list of 
+			labels (one per centre)
 		
 	Returns:
 		Trajectory: The constructed Trajectory object

--- a/site_analysis/builders.py
+++ b/site_analysis/builders.py
@@ -107,22 +107,40 @@ class TrajectoryBuilder:
 	"""
 	
 	def __init__(self) -> None:
-		"""Initialize a TrajectoryBuilder."""
-		self._structure: Optional[Structure] = None
-		self._reference_structure: Optional[Structure] = None
-		self._mobile_species: Optional[Union[str, list[str]]] = None
-		self._atoms: Optional[list[Atom]] = None
+		"""Initialize a TrajectoryBuilder.
+		
+		Creates a new builder with all attributes set to their default values.
+		"""
+		# Call reset() to set all attributes to their default values
+		self.reset()
+	
+	def reset(self) -> 'TrajectoryBuilder':
+		"""Reset the builder state to default values.
+		
+		This method clears all configuration and returns the builder to its
+		initial state. It is called automatically during initialization and
+		after build(), but can also be called explicitly if needed.
+		
+		Returns:
+			self: For method chaining
+		"""
+		self._structure = None
+		self._reference_structure = None
+		self._mobile_species = None
+		self._atoms = None
 		
 		# Alignment options
-		self._align: bool = True
-		self._align_species: Optional[list[str]] = None
-		self._align_metric: str = 'rmsd'
+		self._align = True
+		self._align_species = None
+		self._align_metric = 'rmsd'
 		
 		# Mapping options
-		self._mapping_species: Optional[list[str]] = None
+		self._mapping_species = None
 		
 		# Functions to be called during build() to create sites
-		self._site_generators: list[Callable[[], Sequence[Site]]] = []
+		self._site_generators = []
+		
+		return self
 		
 	def with_structure(self, structure) -> TrajectoryBuilder:
 		"""Set the structure to analyse.
@@ -481,6 +499,9 @@ class TrajectoryBuilder:
 			
 		# Create trajectory
 		trajectory = Trajectory(sites=sites, atoms=self._atoms)
+		
+		# Reset the builder state for future use
+		self.reset()
 		
 		return trajectory
 

--- a/site_analysis/reference_workflow/reference_based_sites.py
+++ b/site_analysis/reference_workflow/reference_based_sites.py
@@ -53,11 +53,13 @@ class ReferenceBasedSites:
 	"""
 	
 	def __init__(self, 
-				 reference_structure: Structure, 
-				 target_structure: Structure, 
-				 align: bool = True, 
-				 align_species: Optional[List[str]] = None, 
-				 align_metric: str = 'rmsd') -> None:
+			 reference_structure: Structure, 
+			 target_structure: Structure, 
+			 align: bool = True, 
+			 align_species: Optional[list[str]] = None, 
+			 align_metric: str = 'rmsd',
+			 align_algorithm: str = 'Nelder-Mead',
+			 align_minimizer_options: Optional[dict[str, Any]] = None) -> None:
 		"""Initialise ReferenceBasedSites with reference and target structures.
 		
 		Args:
@@ -66,6 +68,9 @@ class ReferenceBasedSites:
 			align: Whether to perform structure alignment. Default is True.
 			align_species: Species to use for alignment. Default is all species.
 			align_metric: Metric for alignment ('rmsd', 'max_dist'). Default is 'rmsd'.
+			align_algorithm: Algorithm for optimization ('Nelder-Mead', 'differential_evolution'). 
+							Default is 'Nelder-Mead'.
+			align_minimizer_options: Additional options for the minimizer. Default is None.
 		"""
 		self.reference_structure = reference_structure
 		self.target_structure = target_structure
@@ -77,13 +82,18 @@ class ReferenceBasedSites:
 		
 		# Perform alignment if requested
 		if align:
-			self._align_structures(align_species, align_metric)
+			self._align_structures(
+				align_species, 
+				align_metric, 
+				align_algorithm, 
+				align_minimizer_options
+			)
 		
 		# These will be initialised on first use
 		self._coord_finder: Optional[CoordinationEnvironmentFinder] = None
 		self._index_mapper: Optional[IndexMapper] = None
 		self._site_factory: Optional[SiteFactory] = None
-	
+		
 	def create_polyhedral_sites(self, 
 							  center_species: str, 
 							  vertex_species: Union[str, List[str]], 
@@ -190,13 +200,18 @@ class ReferenceBasedSites:
 		return sites
 	
 	def _align_structures(self, 
-						align_species: Optional[List[str]] = None, 
-						align_metric: str = 'rmsd') -> None:
+						align_species: Optional[list[str]] = None, 
+						align_metric: str = 'rmsd',
+						align_algorithm: str = 'Nelder-Mead',
+						align_minimizer_options: Optional[dict[str, Any]] = None) -> None:
 		"""Align target structure to reference structure.
 		
 		Args:
 			align_species: Species to use for alignment. Default is all species.
 			align_metric: Metric for alignment ('rmsd', 'max_dist'). Default is 'rmsd'.
+			align_algorithm: Algorithm for optimization ('Nelder-Mead', 'differential_evolution'). 
+						Default is 'Nelder-Mead'.
+			align_minimizer_options: Additional options for the minimizer. Default is None.
 			
 		Raises:
 			ValueError: If alignment fails.
@@ -210,7 +225,9 @@ class ReferenceBasedSites:
 				self.reference_structure, 
 				self.target_structure, 
 				species=align_species, 
-				metric=align_metric
+				metric=align_metric,
+				algorithm=align_algorithm,
+				minimizer_options=align_minimizer_options
 			)
 			
 			# Update attributes

--- a/site_analysis/reference_workflow/structure_aligner.py
+++ b/site_analysis/reference_workflow/structure_aligner.py
@@ -19,8 +19,8 @@ sites in one structure based on a template from another structure.
 
 import numpy as np
 from pymatgen.core import Structure
-from scipy.optimize import minimize # type: ignore
-from typing import List, Dict, Tuple, Optional, Union, Any
+from scipy.optimize import minimize
+from typing import Optional, Union, Any
 from site_analysis.tools import calculate_species_distances
 
 class StructureAligner:
@@ -34,15 +34,15 @@ class StructureAligner:
 	def align(self, 
 			reference: Structure, 
 			target: Structure, 
-			species: Optional[List[str]] = None, 
+			species: Optional[list[str]] = None, 
 			metric: str = 'rmsd', 
-			tolerance: float = 0.1) -> Tuple[Structure, np.ndarray, Dict[str, float]]:
+			tolerance: float = 1e-4) -> tuple[Structure, np.ndarray, dict[str, float]]:
 		"""Align reference structure to target structure via translation.
 		
 		Args:
 			reference: Reference structure to be aligned.
 			target: Target structure to align to.
-			species: List of species to use for alignment.
+			species: list of species to use for alignment.
 				If None, all common species will be used.
 			metric: Metric to optimize. Options are:
 				'rmsd': Root mean square deviation
@@ -54,7 +54,7 @@ class StructureAligner:
 			tuple: (aligned_structure, translation_vector, metrics)
 				aligned_structure: The aligned reference structure.
 				translation_vector: The translation vector used for alignment.
-				metrics: Dict with alignment quality metrics.
+				metrics: dict with alignment quality metrics.
 				
 		Raises:
 			ValueError: If the structures cannot be aligned due to different
@@ -89,12 +89,11 @@ class StructureAligner:
 				raise ValueError(f"Unknown metric: {metric}")
 		
 		# Perform optimization
-		from scipy.optimize import minimize
 		result = minimize(
 			objective_function,
 			x0=[0, 0, 0],  # Start with zero translation
 			method='Nelder-Mead',
-			options={'xatol': 1e-4, 'fatol': 1e-4}
+			options={'xatol': tolerance, 'fatol': tolerance}
 		)
 		
 		if not result.success:
@@ -121,16 +120,16 @@ class StructureAligner:
 	def _validate_structures(self, 
 							reference: Structure, 
 							target: Structure, 
-							species: Optional[List[str]] = None) -> List[str]:
+							species: Optional[list[str]] = None) -> list[str]:
 		"""Validate that structures can be aligned and determine species to use.
 		
 		Args:
 			reference: Reference structure
 			target: Target structure
-			species: List of species to use for alignment
+			species: list of species to use for alignment
 			
 		Returns:
-			List of species to use for alignment
+			list of species to use for alignment
 			
 		Raises:
 			ValueError: If structures cannot be aligned

--- a/tests/test_spherical_site.py
+++ b/tests/test_spherical_site.py
@@ -287,6 +287,7 @@ class SphericalSiteTestCase(unittest.TestCase):
         # The result will depend on the specific lattice parameters
         self.assertIsInstance(result, bool)
 
+    
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Various bug fixes and enhancements:
- The `with_spherical_sites` builder method now allows a single radius to be passed for use with all sites.
- Calling builder.build() now resets the build settings, to avoid unintentional reuse of sites or settings.
- Fixed a bug where the `tolerance` argument of the structure aligner tool was not being used for the alignment optimisation.
- Refactored the structure alignment tool for better modularity and to allow the user to select the optimiser used to perform the alignment, plus pass optimiser options if needed. These additional options are now also accessible upstream in Reference Based Sites and builder workflows.